### PR TITLE
Improve the management of non-ascii characters in emails

### DIFF
--- a/form_manager/forms.py
+++ b/form_manager/forms.py
@@ -185,7 +185,9 @@ def receive_response(identifier: str):
     if form_info.get("email_recipients"):
         html_form_response = {}
         for key in form_response:
-            html_form_response[key] = form_response[key].encode('ascii', 'xmlcharrefreplace').decode()
+            html_form_response[key] = (
+                form_response[key].encode("ascii", "xmlcharrefreplace").decode()
+            )
         text_body = "JSON:\n\n"
         text_body += json.dumps(form_response, indent=2, sort_keys=True)
         text_body += "\n\nPython dict:\n\n"
@@ -194,7 +196,9 @@ def receive_response(identifier: str):
         html_body = "<p>JSON:</p>"
         html_body += f"<p><pre><code>{json.dumps(html_form_response, indent=2, sort_keys=True)}</code></pre></p>"
         html_body += "<p>Python dict:</p>"
-        html_body += f"<p><pre><code>{pprint.pformat(html_form_response, indent=2)}</code></pre></p>"
+        html_body += (
+            f"<p><pre><code>{pprint.pformat(html_form_response, indent=2)}</code></pre></p>"
+        )
         html_body += f"<p>Response received: {utils.make_timestamp()} </p>"
         mail.send(
             flask_mail.Message(

--- a/form_manager/forms.py
+++ b/form_manager/forms.py
@@ -182,12 +182,25 @@ def receive_response(identifier: str):
         del form_response["g-recaptcha-response"]
 
     if form_info.get("email_recipients"):
-        email_body = json.dumps(form_response)
-        email_body += "\n\nTime: " + str(utils.make_timestamp())
+        import pprint
+        html_form_response = {}
+        for key in form_response:
+            html_form_response[key] = form_response[key].encode('ascii', 'xmlcharrefreplace').decode()
+        text_body = "JSON:\n\n"
+        text_body += json.dumps(form_response, indent=2, sort_keys=True)
+        text_body += "\n\nPython dict:\n\n"
+        text_body += pprint.pformat(form_response, indent=2)
+        text_body += f"\n\nResponse received: {utils.make_timestamp()}"
+        html_body = "<p>JSON:</p>"
+        html_body += f"<p><pre><code>{json.dumps(html_form_response, indent=2, sort_keys=True)}</code></pre></p>"
+        html_body += "<p>Python dict:</p>"
+        html_body += f"<p><pre><code>{pprint.pformat(html_form_response, indent=2)}</code></pre></p>"
+        html_body += f"<p>Response received: {utils.make_timestamp()} </p>"
         mail.send(
             flask_mail.Message(
                 f"Form from {form_info.get('title')}",
-                body=email_body,
+                html=html_body,
+                body=text_body,
                 recipients=form_info["email_recipients"],
             )
         )

--- a/form_manager/forms.py
+++ b/form_manager/forms.py
@@ -183,27 +183,11 @@ def receive_response(identifier: str):
         del form_response["g-recaptcha-response"]
 
     if form_info.get("email_recipients"):
-        html_form_response = {}
-        for key in form_response:
-            html_form_response[key] = (
-                form_response[key].encode("ascii", "xmlcharrefreplace").decode()
-            )
-        text_body = "JSON:\n\n"
-        text_body += json.dumps(form_response, indent=2, sort_keys=True)
-        text_body += "\n\nPython dict:\n\n"
-        text_body += pprint.pformat(form_response, indent=2)
+        text_body = json.dumps(form_response, indent=2, sort_keys=True, ensure_ascii=False)
         text_body += f"\n\nResponse received: {utils.make_timestamp()}"
-        html_body = "<p>JSON:</p>"
-        html_body += f"<p><pre><code>{json.dumps(html_form_response, indent=2, sort_keys=True)}</code></pre></p>"
-        html_body += "<p>Python dict:</p>"
-        html_body += (
-            f"<p><pre><code>{pprint.pformat(html_form_response, indent=2)}</code></pre></p>"
-        )
-        html_body += f"<p>Response received: {utils.make_timestamp()} </p>"
         mail.send(
             flask_mail.Message(
                 f"Form from {form_info.get('title')}",
-                html=html_body,
                 body=text_body,
                 recipients=form_info["email_recipients"],
             )

--- a/form_manager/forms.py
+++ b/form_manager/forms.py
@@ -1,5 +1,6 @@
 """Endpoints related to forms."""
 import json
+import pprint
 
 import flask
 import flask_mail
@@ -182,7 +183,6 @@ def receive_response(identifier: str):
         del form_response["g-recaptcha-response"]
 
     if form_info.get("email_recipients"):
-        import pprint
         html_form_response = {}
         for key in form_response:
             html_form_response[key] = form_response[key].encode('ascii', 'xmlcharrefreplace').decode()

--- a/form_manager/utils.py
+++ b/form_manager/utils.py
@@ -111,4 +111,3 @@ def has_form_access(username, entry):
         bool: Whether the user has access.
     """
     return username in entry["owners"]
-

--- a/frontend/src/pages/FormResponses.vue
+++ b/frontend/src/pages/FormResponses.vue
@@ -10,7 +10,7 @@
   
   <q-card v-if="Object.keys(urlInfo).length > 0" class="q-my-sm">
     <q-card-section>
-      &lt;form action="{{ urlInfo.submission_url }}" method="{{ urlInfo.method }}"&gt;
+      &lt;form action="{{ urlInfo.submission_url }}" method="{{ urlInfo.method }}" accept-charset="utf-8"&gt;
     </q-card-section>
   </q-card>
   


### PR DESCRIPTION
* Update the suggestion row for how to write the html tag to include `accept-charset="utf-8"`
* Use `ensure_ascii=False` for JSON output

Closes #16 

Mail output:
```
{
  "action": "validate_captcha",
  "comment": "äkö-åäpä&%#%",
  "fname": "äkö-åäpä&%#%",
  "g-recaptcha-response": "",
  "lname": "äkö-åäpä&%#%"
}

Response received: Tue, 07 Jun 2022 09:55:58 CEST
```